### PR TITLE
Fix QueryStrings getting lost when clicking on links with anchors (#)

### DIFF
--- a/src/js/07-userparams-behaviour.js
+++ b/src/js/07-userparams-behaviour.js
@@ -1,53 +1,5 @@
 document.addEventListener('DOMContentLoaded', function () {
 
-  function hasQueryString (url) {
-    // regex pattern for detecting querystring
-    var pattern = new RegExp(/\?.+=.*/g)
-    return pattern.test(url)
-  }
-
-  /*
-   * Thanks to https://gomakethings.com/getting-all-query-string-values-from-a-url-with-vanilla-js/
-  */
-  function getParams (url) {
-    if (!url) url = window.location.href
-    var params = {}
-    var parser = document.createElement('a')
-    parser.href = url
-    var query = parser.search.substring(1)
-    var vars = query.split('&')
-    for (var i = 0; i < vars.length; i++) {
-      var pair = vars[i].split('=')
-      params[pair[0]] = decodeURIComponent(pair[1])
-    }
-    return params
-  }
-
-  function replaceParamsInNodes (node, key, value) {
-    if (node.parentElement) {
-      //console.log('Parent element %s', node.parentElement.nodeName)
-      if (node.parentElement.nodeName === 'code' ||
-        node.parentElement.nodeName === 'CODE') {
-        return
-      }
-    }
-    if (node.nodeType === 3) {
-      var text = node.data
-      node.data = applyPattern(text, key, value)
-    }
-    if (node.nodeType === 1 && node.nodeName !== 'SCRIPT') {
-      for (var i = 0; i < node.childNodes.length; i++) {
-        replaceParamsInNodes(node.childNodes[i], key, value)
-      }
-    }
-  }
-
-  var allParams = getParams()
-  var keys = Object.keys(allParams)
-  for (var i = 0; i < keys.length; i++) {
-    replaceParamsInNodes(document.body, keys[i], allParams[keys[i]])
-  }
-
   //Handle links
   var allQueryPramLinks = document.querySelectorAll('.query-params-link')
   if (allQueryPramLinks) {
@@ -64,29 +16,60 @@ document.addEventListener('DOMContentLoaded', function () {
     allNavLinks.forEach(appendQueryStringToHref)
   }
 
-  function appendQueryStringToHref (el) {
-    var queryString = window.location.search
+  function appendQueryStringToHref(el) {
+    var desiredQueryString = new URLSearchParams(window.location.search)
     var appendQueryString = el.classList.contains('query-params-link') ||
       el.classList.contains('nav-link')
-    if (!hasQueryString(el.href) && queryString) {
-      var href = el.href
-      for (var i = 0; i < keys.length; i++) {
-        href = applyPattern(href, keys[i], allParams[keys[i]])
-      }
-      if (appendQueryString) {
-        el.href = href + queryString
-      } else {
-        el.href = href
+
+    if (desiredQueryString.toString() && appendQueryString) {
+      var hrefURL = new URL(el.href);
+      for (var k of desiredQueryString.keys()) {
+        hrefURL.searchParams.append(k, desiredQueryString.get(k));
       }
 
+      el.href = hrefURL.toString();
     }
   }
 
-  function applyPattern (str, key, value) {
+  // refreshing links
+
+  function replaceParamsInNodes(node, key, value) {
+    if (node.parentElement) {
+      //console.log('Parent element %s', node.parentElement.nodeName)
+      if (node.parentElement.nodeName === 'code' ||
+        node.parentElement.nodeName === 'CODE') {
+        return
+      }
+    }
+    if (node.nodeType === 3) {
+      var text = node.data
+      node.data = applyPattern(text, key, value)
+    }
+    if (node.nodeType === 1 && node.nodeName !== 'SCRIPT') {
+      for (var i = 0; i < node.childNodes.length; i++) {
+        replaceParamsInNodes(node.childNodes[i], key, value)
+      }
+
+      // handle link elements
+      if (node.href) {
+        node.href = applyPattern(node.href, key, value);
+      }
+    }
+  }
+
+  // If there are query parameters (searchparams) in the current window location then 
+  // Iterate over all them replacing text and link-hrefs that contain them
+  var params = new URLSearchParams(window.location.search);
+  for (var k of params.keys()) {
+    replaceParamsInNodes(document.body, k, params.get(k));
+  }
+
+  function applyPattern(str, key, value) {
     //(%25key%25|%key%) %25 is urlencode value of %
     var pattern = '(' + '%25' + key + '%25' +
       '|(?<!-)' + '%' + key + '%' + '(?!-))'
     var re = new RegExp(pattern, 'gi')
     return str.replace(re, value)
   }
-})
+
+});


### PR DESCRIPTION
(Addresses Issue #9) 

Old code was just appending query string to end of URL which is incorrect.  The # needs to come last

Link element href attributes are now subject to search and replace of query string elements

New code uses higher order abstractions (URLSearchParams) to make sure querystring is appended to URL in proper spot in all situations

No longer scan through the dom when there are no query parameters in the window location (used to needlessly try to search and replace empty string)