### PR TITLE
Candidate v0.1.10 release

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,24 @@
+# syntax = docker/dockerfile:1.0-experimental
+FROM registry.access.redhat.com/ubi8/nodejs-12 as podmandevcontainer
+
+USER root
+
+RUN dnf update -y && npm i -g @antora/cli@2.3 @antora/site-generator-default@2.3 \
+    && dnf update -y \
+    && npm rm --global npx && npm install --global npx && npm install --global gulp \
+    && dnf clean all && rm -r /var/cache/dnf
+
+RUN wget https://github.com/mikefarah/yq/releases/download/3.4.0/yq_linux_amd64 -O /usr/local/bin/yq && \
+    chmod 755 /usr/local/bin/yq
+
+RUN wget https://github.com/wercker/stern/releases/download/1.11.0/stern_linux_amd64 -O /usr/local/bin/stern && \
+    chmod 755 /usr/local/bin/stern
+
+RUN curl -L https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux.tar.gz | \
+    tar -xvzf - -C /usr/local/bin/ oc && chmod 755 /usr/local/bin/oc && ln -s /usr/local/bin/oc /usr/local/bin/kubectl
+
+# If running (rootless) podman, keep the root user so that outside the container it will match 
+# the host user.  Otherwise run as default user
+FROM podmandevcontainer AS devcontainer
+RUN chown -R default $HOME
+USER default

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,34 @@
+// For format details, see https://aka.ms/vscode-remote/devcontainer.json or this file's README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.134.0/containers/javascript-node
+{
+	"name": "OpenShift Starter Guide",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"target": "${env:DEVCONTAINER_TARGET_PREFIX}devcontainer",
+	},
+	
+	"runArgs": [
+		"-v", "${env:HOME}/.kube:/opt/app-root/src/.kube:Z",
+		"-v", "${env:HOME}/.gitconfig:/opt/app-root/src/.gitconfig:Z",
+		"-e", "WORKSPACE_ROOT=${containerWorkspaceFolder}"
+	],
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash",
+		"editor.tabCompletion": "on",
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"dbaeumer.vscode-eslint",
+		"ms-azuretools.vscode-docker",
+		"joaompinto.asciidoctor-vscode",
+	],
+	
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [3000],
+
+	// Specifies a command that should be run after the container has been created.
+	"postCreateCommand": "rsync -a .devcontainer/workspace-setup/ ${containerWorkspaceFolder}/.vscode/ --ignore-existing",
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // For format details, see https://aka.ms/vscode-remote/devcontainer.json or this file's README at:
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.134.0/containers/javascript-node
 {
-	"name": "OpenShift Starter Guide",
+	"name": "Course UI",
 	"build": {
 		"dockerfile": "Dockerfile",
 		"target": "${env:DEVCONTAINER_TARGET_PREFIX}devcontainer",

--- a/.devcontainer/workspace-setup/asciidoc.json.code-snippets
+++ b/.devcontainer/workspace-setup/asciidoc.json.code-snippets
@@ -1,0 +1,48 @@
+{
+  "Add Tabs": {
+    "prefix": "tabs",
+    "body": [
+      "[tabs]",
+      "====",
+      "${1:tab1}::",
+      "+",
+      "--",
+      "--",
+      "${2:tab2}::",
+      "+",
+      "--",
+      "--",
+      "===="
+    ],
+    "description": "Add Tabs macro"
+  },
+  "Add Navigation": {
+    "prefix": "nav",
+    "body": [
+      "${1|*,**,***|} xref:${2:page.adoc}[${3:Nav Title}]"
+    ],
+    "description": "Add new navigation"
+  },
+  "Console Input": {
+    "prefix": "input",
+    "body": [
+      "[.console-input]",
+      "[source,${1:bash},subs=\"${2:+macros,+attributes}\"]",
+      "----",
+      "${3:echo \"Hello World\"}",
+      "----"
+    ],
+    "description": "Adds Console Input source fragment"
+  },
+  "Console Output": {
+    "prefix": "output",
+    "body": [
+      "[.console-output]",
+      "[source,${1:bash},subs=\"${2:+macros,+attributes}\"]",
+      "----",
+      "${3:\"Hello World\"}",
+      "----"
+    ],
+    "description": "Adds Console Output source fragment"
+  }
+}

--- a/.devcontainer/workspace-setup/tasks.json
+++ b/.devcontainer/workspace-setup/tasks.json
@@ -1,0 +1,17 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"label": "Build and watch dev-site",
+			"type": "npm",
+			"script": "dev",
+			"problemMatcher": [],
+			"dependsOn":[ "npm install" ]
+		},
+		{
+			"label": "npm install",
+			"type": "npm",
+			"script": "install"
+		}
+	]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /public/
 yarn.lock
 .tool-versions
+
+.vscode/

--- a/preview-src/index.adoc
+++ b/preview-src/index.adoc
@@ -26,6 +26,10 @@ You need to https://console.openshift.com[login,role=userfied-link]
 
 I like %COLOR% color
 
+== Link Testing
+
+Here is a link:index.html?USER=%USER%#liber-recusabo[link^] containing a query string item that should open to "Liber recusabo" in a new window
+
 == Cu solet
 
 Nominavi luptatum eos, an vim hinc philosophia intellegebat.

--- a/preview-src/index.adoc
+++ b/preview-src/index.adoc
@@ -26,6 +26,7 @@ You need to https://console.openshift.com[login,role=userfied-link]
 
 I like %COLOR% color
 
+[#link-testing]
 == Link Testing
 
 Here is a link:index.html?USER=%USER%#liber-recusabo[link^] containing a query string item that should open to "Liber recusabo" in a new window

--- a/preview-src/ui-model.yml
+++ b/preview-src/ui-model.yml
@@ -105,6 +105,9 @@ page:
       - content: Brand&#8217;s Hardware &amp; Software Requirements
         url: /xyz/5.2/index.html
         urlType: internal
+      - content: Link Testing
+        url: '/xyz/5.2/index.html#link-testing'
+        urlType: internal
       - content: Cu Solet
         url: '/xyz/5.2/index.html#cu-solet'
         urlType: internal

--- a/src/js/07-userparams-behaviour.js
+++ b/src/js/07-userparams-behaviour.js
@@ -16,24 +16,24 @@ document.addEventListener('DOMContentLoaded', function () {
     allNavLinks.forEach(appendQueryStringToHref)
   }
 
-  function appendQueryStringToHref(el) {
+  function appendQueryStringToHref (el) {
     var desiredQueryString = new URLSearchParams(window.location.search)
     var appendQueryString = el.classList.contains('query-params-link') ||
       el.classList.contains('nav-link')
 
     if (desiredQueryString.toString() && appendQueryString) {
-      var hrefURL = new URL(el.href);
+      var hrefURL = new URL(el.href)
       for (var k of desiredQueryString.keys()) {
-        hrefURL.searchParams.append(k, desiredQueryString.get(k));
+        hrefURL.searchParams.append(k, desiredQueryString.get(k))
       }
 
-      el.href = hrefURL.toString();
+      el.href = hrefURL.toString()
     }
   }
 
   // refreshing links
 
-  function replaceParamsInNodes(node, key, value) {
+  function replaceParamsInNodes (node, key, value) {
     if (node.parentElement) {
       //console.log('Parent element %s', node.parentElement.nodeName)
       if (node.parentElement.nodeName === 'code' ||
@@ -52,19 +52,19 @@ document.addEventListener('DOMContentLoaded', function () {
 
       // handle link elements
       if (node.href) {
-        node.href = applyPattern(node.href, key, value);
+        node.href = applyPattern(node.href, key, value)
       }
     }
   }
 
-  // If there are query parameters (searchparams) in the current window location then 
-  // Iterate over all them replacing text and link-hrefs that contain them
-  var params = new URLSearchParams(window.location.search);
+  // If there are query parameters (searchparams) in the current window location
+  // then iterate over all them replacing text and link-hrefs that contain them
+  var params = new URLSearchParams(window.location.search)
   for (var k of params.keys()) {
-    replaceParamsInNodes(document.body, k, params.get(k));
+    replaceParamsInNodes(document.body, k, params.get(k))
   }
 
-  function applyPattern(str, key, value) {
+  function applyPattern (str, key, value) {
     //(%25key%25|%key%) %25 is urlencode value of %
     var pattern = '(' + '%25' + key + '%25' +
       '|(?<!-)' + '%' + key + '%' + '(?!-))'
@@ -72,4 +72,4 @@ document.addEventListener('DOMContentLoaded', function () {
     return str.replace(re, value)
   }
 
-});
+})

--- a/src/js/07-userparams-behaviour.js
+++ b/src/js/07-userparams-behaviour.js
@@ -24,7 +24,7 @@ document.addEventListener('DOMContentLoaded', function () {
     if (desiredQueryString.toString() && appendQueryString) {
       var hrefURL = new URL(el.href)
       for (var k of desiredQueryString.keys()) {
-        hrefURL.searchParams.append(k, desiredQueryString.get(k))
+        hrefURL.searchParams.set(k, desiredQueryString.get(k))
       }
 
       el.href = hrefURL.toString()

--- a/src/js/07-userparams-behaviour.js
+++ b/src/js/07-userparams-behaviour.js
@@ -1,27 +1,33 @@
 document.addEventListener('DOMContentLoaded', function () {
 
-  //Handle links
-  var allQueryPramLinks = document.querySelectorAll('.query-params-link')
-  if (allQueryPramLinks) {
-    allQueryPramLinks.forEach(appendQueryStringToHref)
+  // If there is a query string, we need to fix up the page to make sure the query string is properly preserved
+  var desiredQueryString = new URLSearchParams(window.location.search)
+  if (desiredQueryString.toString()) {
+    preserveQueryString(desiredQueryString)
+    // If there are query parameters (searchparams) in the current window location
+    // then iterate over all them replacing text and link-hrefs that contain them
+    for (var k of desiredQueryString.keys()) {
+      replaceParamsInNodes(document.body, k, desiredQueryString.get(k))
+    }
   }
 
-  var pramLinks = document.querySelectorAll('.params-link')
-  if (pramLinks) {
-    pramLinks.forEach(appendQueryStringToHref)
-  }
+  function preserveQueryString (desiredQueryString) {
+    //Handle links
+    var allQueryParamLinks = document.querySelectorAll('.query-params-link, .home-link, .params-link, .nav-link')
+    if (allQueryParamLinks) {
+      allQueryParamLinks.forEach(appendQueryStringToHref)
+    }
 
-  var allNavLinks = document.querySelectorAll('.nav-link')
-  if (allNavLinks) {
-    allNavLinks.forEach(appendQueryStringToHref)
+    // Handle breadcrumb navigation links
+    var paramLinks = document.querySelectorAll('.breadcrumbs ul li a')
+    if (paramLinks) {
+      paramLinks.forEach(appendQueryStringToHref)
+    }
   }
 
   function appendQueryStringToHref (el) {
-    var desiredQueryString = new URLSearchParams(window.location.search)
-    var appendQueryString = el.classList.contains('query-params-link') ||
-      el.classList.contains('nav-link')
-
-    if (desiredQueryString.toString() && appendQueryString) {
+    // NOTE: desiredQueryString captured from above
+    if (desiredQueryString.toString()) {
       var hrefURL = new URL(el.href)
       for (var k of desiredQueryString.keys()) {
         hrefURL.searchParams.set(k, desiredQueryString.get(k))
@@ -55,13 +61,6 @@ document.addEventListener('DOMContentLoaded', function () {
         node.href = applyPattern(node.href, key, value)
       }
     }
-  }
-
-  // If there are query parameters (searchparams) in the current window location
-  // then iterate over all them replacing text and link-hrefs that contain them
-  var params = new URLSearchParams(window.location.search)
-  for (var k of params.keys()) {
-    replaceParamsInNodes(document.body, k, params.get(k))
   }
 
   function applyPattern (str, key, value) {


### PR DESCRIPTION
Updates to the course-ui.  See candidate release in my repo [here](https://github.com/hatmarch/course-ui/releases/tag/v0.1.10).  I have tested this release with the latest version of the [openshift-starter-guide](https://github.com/redhat-scholars/openshift-starter-guides)

* Cleans up queryParam preservation and substitution code to be more efficient
* Changes to conform to linter
* Breadcrumb links now have query string preserved
* Fixes an issue where queryStrings could get repeated causing URL string to grow indefinitely (eventually breaking navigation)

This also adds:

* some .devcontainer support for those wishing to run the testing environment in VSCode remote
* Updates to the preview site for testing links with queryParams embedded in them