### PR TITLE
Add better support for ignoring query string replacement (v0.1.11)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ yarn.lock
 .tool-versions
 
 .vscode/
+
+#MacOSX
+.DS_Store

--- a/preview-src/index.adoc
+++ b/preview-src/index.adoc
@@ -5,6 +5,7 @@ Author Name
 :!example-caption:
 :!table-caption:
 :page-pagination:
+:USER: %USER%
 
 image:multirepo-ssg.svg[Multirepo SSG,200,float=right]
 Platonem complectitur mediocritatem ea eos.
@@ -30,6 +31,31 @@ I like %COLOR% color
 == Link Testing
 
 Here is a link:index.html?USER=%USER%#liber-recusabo[link^] containing a query string item that should open to "Liber recusabo" in a new window
+
+[#query-string-replacement-testing]
+== Query String Replacement Testing
+
+_If the `USER` query string has been set in the URL, then you should see it replaced (or not) below according to the text_
+
+[.console-output]
+[source,bash,subs="+macros,+attributes"]
+----
+This should show the USER substitution: {USER}
+----
+
+This should also show the USER substitution: `%USER%`
+
+[.no-query-replace]
+[.console-output]
+[source,bash,noquery,subs="+macros,+attributes"]
+----
+This should not: pass:[%USER%]
+----
+
+And this also should not: [.no-query-replace]`%USER%`
+
+You should see USER replacement here: %USER% but not here: [.no-query-replace]#%USER%#
+
 
 == Cu solet
 

--- a/preview-src/ui-model.yml
+++ b/preview-src/ui-model.yml
@@ -108,6 +108,9 @@ page:
       - content: Link Testing
         url: '/xyz/5.2/index.html#link-testing'
         urlType: internal
+      - content: Query String Replacement Testing
+        url: '/xyz/5.2/index.html#query-string-replacement-testing'
+        urlType: internal
       - content: Cu Solet
         url: '/xyz/5.2/index.html#cu-solet'
         urlType: internal

--- a/src/js/07-userparams-behaviour.js
+++ b/src/js/07-userparams-behaviour.js
@@ -40,13 +40,11 @@ document.addEventListener('DOMContentLoaded', function () {
   // refreshing links
 
   function replaceParamsInNodes (node, key, value) {
-    if (node.parentElement) {
-      //console.log('Parent element %s', node.parentElement.nodeName)
-      if (node.parentElement.nodeName === 'code' ||
-        node.parentElement.nodeName === 'CODE') {
-        return
-      }
+    // Don't descend into any nodes that are children of the no-query-replace class
+    if ((typeof node.classList !== 'undefined') && (node.classList.contains('no-query-replace'))) {
+      return
     }
+
     if (node.nodeType === 3) {
       var text = node.data
       node.data = applyPattern(text, key, value)


### PR DESCRIPTION
Instead of skipping CODE or code blocks in the DOM, any node (or descendant of a node) with the no-query-replace class will not get evaluated for query-param substitution

Updated index.adoc to test this and demonstrate in some common cases how this would work (including code blocks)