### PR TITLE
allow hypen prefix in substitutions

### DIFF
--- a/preview-src/index-username.adoc
+++ b/preview-src/index-username.adoc
@@ -1,0 +1,1 @@
+This is an empty page used to help verify the parameter replacement in content containing leading hyphens, i.e `%NAME%` should be replaced in both `hello-%NAME%` and `hello %NAME%`.

--- a/preview-src/index.adoc
+++ b/preview-src/index.adoc
@@ -32,6 +32,10 @@ I like %COLOR% color
 
 Here is a link:index.html?USER=%USER%#liber-recusabo[link^] containing a query string item that should open to "Liber recusabo" in a new window
 
+This link (link:index.html?USER=username#link-testing[index.html?USER=username]) that will set the `USER` querystring parameter to `username` and return to this section.
+
+This link should substitute the `USER` queryparam into the URL itself: link:index-%USER%.html?USER=%USER%#link-testing[index-%USER%.html^]
+
 [#query-string-replacement-testing]
 == Query String Replacement Testing
 

--- a/src/js/07-userparams-behaviour.js
+++ b/src/js/07-userparams-behaviour.js
@@ -78,8 +78,14 @@ document.addEventListener('DOMContentLoaded', function () {
 
   function applyPattern (str, key, value) {
     //(%25key%25|%key%) %25 is urlencode value of %
-    var pattern = '(' + '%25' + key + '%25' +
-      '|(?<!-)' + '%' + key + '%' + '(?!-))'
+    var pattern = '(' + '%25' + key + '%25' + '|' + '%' + key + '%' + ')'
+
+    // The following pattern was introduced in commit db18c1dca8e101d0f3a2e512c43ada19168e5afe,
+    // but it's not clear why the negative lookbehind was added. Keeping here
+    // in case we need a revert in the future
+    // var pattern = '(' + '%25' + key + '%25' +
+    //   '|(?<!-)' + '%' + key + '%' + '(?!-))'
+
     var re = new RegExp(pattern, 'gi')
     return str.replace(re, value)
   }


### PR DESCRIPTION
Refer to issue #16 for details. 

The update in *preview-src/index.adoc* can be used to verify the change. Prior to the change `index-%USER%.html` would be unchanged since the regex would explicitly ignore it for substitution due to the leading hyphen. After the change the `%USER%` placeholder will be replaced by whatever the query parameter of the same name is set to.